### PR TITLE
Display days is now configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ export default {
 
 You can stop the countdown timer anytime by passing `true` (Boolean) with `stop` props.
 
+You can decide whether to show the days when they are zero by passing `true` (Boolean) with `showZeroDays` props.
+
+Example:
+
+```
+<div class="days-remaining">
+    <Countdown :end="timerEnd" :showZeroDays="true"></Countdown>
+</div>
+```
 
 ### Caution 
 

--- a/src/Countdown.vue
+++ b/src/Countdown.vue
@@ -1,6 +1,6 @@
 <template>
     <ul class="vuejs-countdown">
-        <li v-if="days > 0">
+        <li v-if="displayDays">
             <p class="digit">{{ days | twoDigits }}</p>
             <p class="text">{{ days > 1 ? 'days' : 'day' }}</p>
         </li>
@@ -33,7 +33,11 @@ export default {
         },
         stop: {
             type: Boolean
-        }
+        },
+        showZeroDays: {
+            type: Boolean,
+            default: false
+        },
     },
     data() {
         return {
@@ -73,6 +77,9 @@ export default {
 
         days() {
             return Math.trunc(this.diff / 60 / 60 / 24)
+        },
+        displayDays() {
+            return this.showZeroDays || this.days > 0
         }
     },
     watch: {


### PR DESCRIPTION
The user can now decide whether to show the days when they are zero by passing `true` (Boolean) with `showZeroDays` props.

Example:

```
<div class="days-remaining">
    <Countdown :end="timerEnd" :showZeroDays="true"></Countdown>
</div>
```
